### PR TITLE
Update URL to modules list + Use same icon as in the forum

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -64,7 +64,7 @@
                 <p><br><a class="btn btn-primary" href="https://github.com/MagicMirrorOrg/MagicMirror" target="_blank">Go to the Repository &raquo;</a></p>
             </div>
             <div class="col-md-3 text-center animated fadeInUp">
-                <i class="fa fa-4x fa-plug" aria-hidden="true"></i>
+                <i class="fa fa-4x fa-list" aria-hidden="true"></i>
                 <h2>Modular</h2>
                 <p>The core of MagicMirror² contains a strong API which allows 3rd party developers to build additional modules. Modules you can use. Modules you can develop.</p>
                 <p><br><a class="btn btn-primary" href="https://modules.magicmirror.builders/" target="_blank">Check out the Modules &raquo;</a></p>

--- a/public/index.html
+++ b/public/index.html
@@ -32,7 +32,7 @@
                     </li>
                     <li><a href="https://github.com/MagicMirrorOrg/MagicMirror"><i class="fa fa-fw fa-github" aria-hidden="true"></i> Repository</a></li>
                     <li><a href="https://docs.magicmirror.builders"><i class="fa fa-fw fa-book" aria-hidden="true"></i> Docs</a></li>
-                    <li><a href="https://github.com/MagicMirrorOrg/MagicMirror/wiki/3rd-Party-Modules"><i class="fa fa-fw fa-plug" aria-hidden="true"></i> Modules</a></li>
+                    <li><a href="https://modules.magicmirror.builders/"><i class="fa fa-fw fa-list" aria-hidden="true"></i> Modules</a></li>
                     <li><a href="https://forum.magicmirror.builders"><i class="fa fa-fw fa-users" aria-hidden="true"></i> Forum</a></li>
                     <li><a href="https://discord.gg/J5BAtvx"><i class="fa fa-fw fa-simplybuilt" aria-hidden="true"></i> Discord</a></li>
                     <li><a href="https://michaelteeuw.nl/tag/magicmirror"><i class="fa fa-fw fa-rss" aria-hidden="true"></i> Blog</a></li>
@@ -67,7 +67,7 @@
                 <i class="fa fa-4x fa-plug" aria-hidden="true"></i>
                 <h2>Modular</h2>
                 <p>The core of MagicMirror² contains a strong API which allows 3rd party developers to build additional modules. Modules you can use. Modules you can develop.</p>
-                <p><br><a class="btn btn-primary" href="https://github.com/MagicMirrorOrg/MagicMirror/wiki/3rd-party-modules" target="_blank">Check out the Modules &raquo;</a></p>
+                <p><br><a class="btn btn-primary" href="https://modules.magicmirror.builders/" target="_blank">Check out the Modules &raquo;</a></p>
             </div>
             <div class="col-md-3 text-center animated fadeInUp">
                 <i class="fa fa-4x fa-book" aria-hidden="true"></i>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the "Modules" section links on the homepage to point to a new URL.
  - Changed the associated icon for the "Modules" section from a plug to a list icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->